### PR TITLE
Removed Useless Use of Grep, uses of 'find' updated to be safer

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -12,7 +12,7 @@ echo -e "${infoColor}Cleaning ccaches${noColor}"
 rm -rf ~/.ccache/
 
 # Garbage collects all your git repos
-gits="$(find | grep '\.git$')"
+gits="$(find -type d -name '*.git')"
 home="$(pwd)"
 while read -r git; do
     echo -e "${infoColor}Cleaning ${successColor}$git${noColor}"
@@ -21,7 +21,7 @@ done <<< "$gits"
 
 # Garbage collects all your compiled java code
 # This can get really intense when you take 162
-classes="$(find | grep '\.class$')"
+classes="$(find -type f -name '*.class')"
 while read -r class; do
     if [ -z "$class" ]
     then


### PR DESCRIPTION
I removed the Useless Use of Grep by instead using the `find` command's built-in pattern matching flag.  I also changed it to only return directories for the git garbage collection step, and only return normal files for the class cleanup (otherwise, for example, naming a file `.git` would potentially do fun things).

Elementary testing resulted in speed improvements, leading me to believe this version is now Web Scale™, and read to meet your Big Data™ needs.
